### PR TITLE
Adding Get Upcoming Shift Endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ __pycache__/
 local_settings.py
 db.sqlite3
 media
+Notes.md
 
 ### Linux ###
 *~

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ dockerpty==0.4.1
 docopt==0.6.2
 drf-yasg==1.20.0
 ecdsa==0.16.0
-Faker==5.6.1
+Faker==8.12.1
 future==0.16.0
 gunicorn==20.0.4
 helpdev==0.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,6 +49,7 @@ packaging==20.8
 paramiko==2.7.2
 pathspec==0.5.9
 pip-autoremove==0.9.1
+psycopg2==2.9.1
 psycopg2-binary==2.8.6
 pycparser==2.20
 PyJWT==1.7.1

--- a/restapi/serializers/__init__.py
+++ b/restapi/serializers/__init__.py
@@ -1,3 +1,4 @@
 from .member_serializers import *
 from .sober_bro_shift_serializers import *
 from .sober_bro_serializer import *
+from .next_shift_serializer import *

--- a/restapi/serializers/next_shift_serializer.py
+++ b/restapi/serializers/next_shift_serializer.py
@@ -1,0 +1,10 @@
+from rest_framework import serializers
+
+from restapi.models.members import Member
+
+
+class UpcomingSoberBroSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Member
+        fields = ['name', "phone"]
+        depth = 1

--- a/restapi/tests/api_tests/sober-bros/test_member_shift_assignation_operations.py
+++ b/restapi/tests/api_tests/sober-bros/test_member_shift_assignation_operations.py
@@ -179,7 +179,7 @@ class ApiTests(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertTrue('member' in content)
-        self.assertEqual(content['member'], "The member you're trying to delete is not currenly a part of this shift.")
+        self.assertEqual(content['member'], "The member you're trying to delete is not currently a part of this shift.")
         self.assertEqual(SoberBro.objects.filter(shift=self.shift).count(), 4)
 
     def test_delete_sb_member_id_not_included(self):

--- a/restapi/tests/api_tests/sober-bros/test_next_sb_functionality.py
+++ b/restapi/tests/api_tests/sober-bros/test_next_sb_functionality.py
@@ -1,0 +1,96 @@
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from restapi.tests.testing_utilities import *
+from restapi.models.sober_bros import SoberBro
+from restapi.models.sober_bro_shifts import SoberBroShift
+
+import datetime
+import pytz
+
+
+class ApiTests(APITestCase):
+    def setUp(self):
+        four_members = list()
+
+        for x in range(0, 4):
+            four_members.append(generate_fake_new_user())
+
+        self.sbs = four_members
+
+        timezone = pytz.timezone("America/Denver")
+        now = datetime.datetime.now()
+
+        two_hours = datetime.timedelta(hours=2)
+
+        now = timezone.localize(now)
+
+        shift = SoberBroShift.objects.create(
+            date=datetime.datetime.today().date(),
+            title="Test Shift",
+            time_start=now,
+            time_end=(now + two_hours),
+            capacity=5
+        )
+
+        sbs = list()
+
+        for member in four_members:
+            sbs.append(SoberBro.objects.create(
+                shift=shift,
+                member=member
+            ))
+
+        self.shift = shift
+
+    def test_get_next_sb_shift(self):
+        member = generate_fake_new_user(True)
+        client = get_authed_client(member.name, 'fake_password')
+
+        timezone = pytz.timezone("America/Denver")
+        now = datetime.datetime.now()
+        now = timezone.localize(now)
+
+        five_minutes = datetime.timedelta(minutes=5)
+        two_hours = datetime.timedelta(hours=2)
+
+        shift = SoberBroShift.objects.create(
+            date=now.date(),
+            time_start=now + five_minutes,
+            time_end=now + two_hours,
+            title="Test Shift",
+            capacity=5
+        )
+
+        link = SoberBro.objects.create(
+            shift=shift,
+            member=member
+        )
+
+        response = client.get('/api/v1/next-sb-shift/', format='json')
+        content = get_response_content(response)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(content), 1)
+
+        self.assertEqual(content[0]["title"], "Test Shift")
+        self.assertTrue('date' in content[0])
+
+        self.assertEqual(len(content[0]["brothers"]), 1)
+        brother = content[0]["brothers"][0]
+        self.assertEqual(brother["name"], member.name)
+        self.assertEqual(brother["phone"], member.phone)
+
+    def test_get_next_sb_shift_no_shifts(self):
+        member = generate_fake_new_user(True)
+        client = get_authed_client(member.name, 'fake_password')
+
+        response = client.get('/api/v1/next-sb-shift/', format='json')
+        content = get_response_content(response)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue("no_shifts" in content)
+
+    def test_unauthed_get_next_sb_shift(self):
+        response = self.client.get('/api/v1/next-sb-shift/', format='json')
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)

--- a/restapi/tests/api_tests/sober-bros/test_sb_shift_CRUD_operations.py
+++ b/restapi/tests/api_tests/sober-bros/test_sb_shift_CRUD_operations.py
@@ -43,7 +43,7 @@ class ApiTests(APITestCase):
 
         self.shift = shift
 
-    def test_unathed_shift_gets(self):
+    def test_unauthed_shift_gets(self):
         response = self.client.get('/api/v1/sober-bro-shift/', format='json')
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 

--- a/restapi/urls.py
+++ b/restapi/urls.py
@@ -8,6 +8,7 @@ from restapi import views
 router = routers.DefaultRouter()
 router.register(r'member', views.MemberViewSet, basename='member')
 router.register(r'sober-bro-shift', views.SoberBroShiftViewSet, basename='sober-bro-shift')
+router.register(r'next-sb-shift', views.NextShiftViewSet, basename='next-shift')
 
 schema_view = get_schema_view(
     openapi.Info(

--- a/restapi/views/__init__.py
+++ b/restapi/views/__init__.py
@@ -1,2 +1,3 @@
 from .member_views import *
 from .sober_bro_shift_views import *
+from .next_shift_views import *

--- a/restapi/views/next_shift_views.py
+++ b/restapi/views/next_shift_views.py
@@ -67,3 +67,16 @@ class NextShiftViewSet(ViewSet, CustomPaginationMixin):
             current_shift["brothers"] = brothers_list
 
         return Response(serializer.data)
+
+    def get_permissions(self):
+        """
+        Instantiates and returns the list of permissions that this view requires.
+        """
+
+        admin_only = ['list']
+
+        if self.action in admin_only:
+            permission_classes = [IsAdminUser]
+        else:
+            permission_classes = [IsAuthenticated]
+        return [permission() for permission in permission_classes]

--- a/restapi/views/next_shift_views.py
+++ b/restapi/views/next_shift_views.py
@@ -1,0 +1,69 @@
+import datetime
+import pytz
+from json import loads, dumps
+
+from django.core.exceptions import ObjectDoesNotExist
+from django.shortcuts import get_object_or_404
+from rest_framework import status
+from rest_framework.decorators import action
+from rest_framework.permissions import IsAuthenticated, IsAdminUser
+from rest_framework.response import Response
+from rest_framework.settings import api_settings
+from rest_framework.viewsets import ViewSet
+
+from restapi.mixins import CustomPaginationMixin
+from restapi.models.members import Member
+from restapi.models.sober_bro_shifts import SoberBroShift
+from restapi.models.sober_bros import SoberBro
+from restapi.serializers import SoberBroSerializer
+from restapi.serializers import SoberBroShiftSerializer
+from restapi.serializers import UpcomingSoberBroSerializer
+
+
+class NextShiftViewSet(ViewSet, CustomPaginationMixin):
+
+    def list(self, request):
+        """
+        Returns a list of shifts beginning in the next 15 minutes, and their associated sober bros.
+        """
+        tz = pytz.timezone('America/Denver')
+        now = datetime.datetime.now(tz)
+        max_start = now + datetime.timedelta(minutes=15)
+
+        try:
+            data = SoberBroShift.objects.filter(
+                date=now.date(),
+                time_start__gte=now,
+                time_start__lt=max_start,
+                time_end__gt=now
+            )
+        except Exception as e:
+            print(str(e))
+            return Response(
+                {
+                    "error": "Encountered an unexpected error"
+                },
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
+
+        if len(data) == 0:
+            return Response(
+                {
+                    "no_shifts": "There are no shifts beginning in the next 15 minutes."
+                },
+                status=status.HTTP_200_OK
+            )
+
+        serializer = SoberBroShiftSerializer(data, many=True)
+
+        for current_shift in serializer.data:
+            assigned_brothers = SoberBro.objects.filter(shift=current_shift["id"])
+
+            brothers_list = []
+
+            for brother in assigned_brothers:
+                brothers_list.append(UpcomingSoberBroSerializer(brother.member).data)
+
+            current_shift["brothers"] = brothers_list
+
+        return Response(serializer.data)

--- a/restapi/views/sober_bro_shift_views.py
+++ b/restapi/views/sober_bro_shift_views.py
@@ -103,7 +103,7 @@ class SoberBroShiftViewSet(ViewSet, CustomPaginationMixin):
         if shift.count() == 0:
             return Response(
                 {
-                    "member": "The member you're trying to delete is not currenly a part of this shift."
+                    "member": "The member you're trying to delete is not currently a part of this shift."
                 },
                 status=status.HTTP_400_BAD_REQUEST
             )


### PR DESCRIPTION
# Description

This PR implementes the `/api/v1/next-sb-shift`, which will be polled by the Slackbot to notify the sb channel.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Manual testing using Postman, and unit testing using Nose.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
